### PR TITLE
Fix hard coding of taxonomy to use given taxonomy when running author migration

### DIFF
--- a/cfpb-wp-cli.php
+++ b/cfpb-wp-cli.php
@@ -3,7 +3,7 @@
  * Plugin Name: CFPB WP CLI Commands
  * Plugin URI: https://github.com/cfpb/cfpb-wp-cli
  * Description: A collection of wp-cli plugins we use at CFPB
- * Version: 1.0
+ * Version: 1.0.1
  * Author: Greg Boone, CFPB
  * Author URI: https://cfpb.github.io/
  * License: Public Domain

--- a/library.php
+++ b/library.php
@@ -116,13 +116,13 @@ class CLI_Common extends \WP_CLI_COMMAND {
         return $posts;
     }
 
-    protected function set_author_terms($object_id, $terms) {
+    protected function set_author_terms($object_id, $terms, $taxonomy = 'author') {
         foreach ( $terms as $k => $a ) {
-            if ( has_term($a, 'author', $object_id ) ) {
+            if ( has_term($a, $taxonomy, $object_id ) ) {
                 unset($terms, $k);
             }
             if ( !empty( $terms ) ) {
-                wp_set_object_terms( $object_id, $terms, 'author', $append = false );
+                wp_set_object_terms( $object_id, $terms, $taxonomy, $append = false );
             }
         }
     }

--- a/migrate.php
+++ b/migrate.php
@@ -86,9 +86,11 @@ class Migrate_Command extends CLI_Common {
         if ( empty($args) && taxonomy_exists( 'author' ) ) {
             $to = 'the author taxonomy';
             $type = true;
+            $taxonomy = 'author';
         } elseif ( is_array($args) && taxonomy_exists($args[0]) ) {
             $to = "taxonomy '{$args[0]}'";
             $type = true;
+            $taxonomy = $args[0];
         } elseif ( isset($args) ) {
             $to = "custom field '{$args[0]}'";
             $type = $args[0];
@@ -111,7 +113,7 @@ class Migrate_Command extends CLI_Common {
                 $author_name = get_the_author_meta('display_name', $authorID );
                 $terms = $this->split_by_comma_or_and($author_name);
                 if ( $type === true ) {
-                    $this->set_author_terms($p->ID, $terms);
+                    $this->set_author_terms($p->ID, $terms, $taxonomy);
                 } else {
                     $this->set_author_as_meta($p->ID, $terms, $type);
                 }


### PR DESCRIPTION
This fixes a bug that prevents specifying a taxonomy to migrate the native authors to. 

@Scotchester 